### PR TITLE
Fix build output directory in workflow (#46)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - develop
 permissions:
   contents: write
-  
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -32,5 +32,5 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4.6.3
         with:
           branch: gh-pages
-          folder: .svelte-kit/output
+          folder: build
           ssh-key: ${{ secrets.GH_PAGES_DEPLOY_KEY }}


### PR DESCRIPTION
* build(*): Migrate to SvelteKit-4 | Update Build

* build(ci.yml): Add develop branch to test in PRs

* build(ci): Update build server command

BREAKING CHANGE: Build & deploy process

* refactor(footer): Remove link to Galileo

Since Galileo is supposed to be a route, build it separately

Temporarily

* build(ci): change cd build command

* chore: Remove trailing logo.svg

* Update ci.yml

Add PAT mention for gh pages

* Update ci.yml

Add write permisssion to ci script

* Update ci.yml

* Update ci.yml

Add deploy key instead of PAT

* build(ci.yml): Replace output folder with build